### PR TITLE
[UPGRADE]: ffmpegvideosource.cpp upgraded with new FFMPEG functions. Python scripts restructured.

### DIFF
--- a/dfd_to_videoevents.py
+++ b/dfd_to_videoevents.py
@@ -7,9 +7,6 @@ import numpy as np
 import argparse
 import skimage.morphology as morph
 
-
-import pdb
-
 params = {'diffthresh': 7,
           'filter_lengths': 11,
           'proximity': 8}
@@ -91,18 +88,18 @@ def write_video_events(movie_name, events_list):
 
     fid.close()
 
-parser = argparse.ArgumentParser(description='Generate videoevents')
-parser.add_argument('--base_dir', type=str, help='Base directory')
-parser.add_argument('--dfd_path', type=str, help='Path to dfd file')
-parser.add_argument('--imdb_key', type=str, help='IMDb key')
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Generate videoevents')
+    parser.add_argument('--base_dir', type=str, help='Base directory')
+    parser.add_argument('--dfd_path', type=str, help='Path to dfd file')
+    parser.add_argument('--imdb_key', type=str, help='IMDb key')
     
     args = parser.parse_args()
     dfd_fname = args.dfd_path
 
-    assert os.path.exists(dfd_fname), 'DFD file does not exist at ' + dfd_name
+    assert os.path.exists(dfd_fname), 'DFD file does not exist at ' + dfd_fname
 
     with open(dfd_fname, 'r') as fid:
         dfd_info = fid.readlines()

--- a/dump_frames_of_shot.py
+++ b/dump_frames_of_shot.py
@@ -69,12 +69,12 @@ def main(video_name, video_fname):
         fn += 1
 
 
-parser = argparse.ArgumentParser(description='Process video file inputs')
-parser.add_argument('--video_fname', type=str, help='Video file path')
-parser.add_argument('--imdb_key', type=str, help='IMDb key')
-parser.add_argument('--base_dir', type=str, help='Base directory')
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process video file inputs')
+    parser.add_argument('--video_fname', type=str, help='Video file path')
+    parser.add_argument('--imdb_key', type=str, help='IMDb key')
+    parser.add_argument('--base_dir', type=str, help='Base directory')
     # get arguments
     args = parser.parse_args()
     if args.imdb_key is not None:

--- a/ffmpegvideosource.hpp
+++ b/ffmpegvideosource.hpp
@@ -33,7 +33,7 @@ class AVStreamConverter
 {
     public:
 
-        AVStreamConverter(PixelFormat src_format, int width, int height);
+        AVStreamConverter(AVPixelFormat src_format, int width, int height);
 
         ~AVStreamConverter();
 

--- a/mat_index.py
+++ b/mat_index.py
@@ -45,14 +45,13 @@ def process(video_fname, imdb_key):
     print('Completed writing to', matidx_fname)
 
 
-parser = argparse.ArgumentParser(description='Process video file inputs')
-parser.add_argument('--video_fname', type=str, help='Video file path')
-parser.add_argument('--imdb_key', type=str, help='IMDb key')
-parser.add_argument('--base_dir', type=str, help='Base directory')
-
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process video file inputs')
+    parser.add_argument('--video_fname', type=str, help='Video file path')
+    parser.add_argument('--imdb_key', type=str, help='IMDb key')
+    parser.add_argument('--base_dir', type=str, help='Base directory')
     args = parser.parse_args()
-    print (args)
+    print(args)
     if args.imdb_key is not None:
         assert args.imdb_key.startswith('tt'), 'Invalid IMDb key'
         print ('Running for {}\n{}'.format(args.imdb_key, args.video_fname))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+argparse==1.4.0
+av==9.2.0
+imageio==2.19.1
+imageio-ffmpeg==0.4.7
+numpy==1.22.3
+opencv-contrib-python==4.5.5.64
+pyparsing==3.0.9
+scikit-image==0.19.2

--- a/run_shot_detection.sh
+++ b/run_shot_detection.sh
@@ -1,10 +1,15 @@
+echo "Note: Don't put backslash at end of the path string argument."
 video_path="$1"
 out_dir="$2"
 moviefile_base=$(basename "$video_path")
 moviefile=$(echo "$moviefile_base" | sed -e 's/\.[^.]*$//')
-movie_path="${out_dir}/${moviefile}/"
-mkdir $movie_path
+movie_path="${out_dir}/${moviefile}"
+mkdir -p $movie_path
 out_dfd_file="${movie_path}/${moviefile}.dfd"
+echo "Movie File Name: "$moviefile
+echo "DFD File is at: "$out_dfd_file
+echo "Video-Path: "$video_path
+echo "Output Directory: "$out_dir
 ./ShotDetect "$video_path" "$out_dfd_file"
 python mat_index.py --video_fname "$video_path" --base_dir "$out_dir"
 python dfd_to_videoevents.py --base_dir "$out_dir" --dfd_path "$out_dfd_file"


### PR DESCRIPTION
Following are the changes in `ffmpedvideosource.cpp`
1. Line 04: Added `#include <opencv2/core/types_c.h>`
2. Line 30: `PixelFormat` -> `AVPixelFormat`
3. Line 34: `PIX_FMT_RGB24` -> `AV_PIX_FMT_RGB24`
4. Line 116 & 117: `avcodec_alloc_frame()` -> `av_frame_alloc()` as this has been deprecated ([Link](https://www.ffmpeg.org/doxygen/2.2/group__lavc__core.html#gaa42c02e54b6ed14066f13b9188bdc3ab)).
5. Line 193: `CODEC_CAP_DELAY` -> `AV_CODEC_CAP_DELAY`. Can be verifed at [here](https://github.com/FFmpeg/FFmpeg).

In `.py` scripts, shifted argument parsing within `if __name__ == "__main__"` block.